### PR TITLE
Allow the gonode spawn to call a compiled .go file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,11 @@ local.properties
 # PDT-specific
 .buildpath
 
+#################
+## Intellij
+#################
+
+.idea/
 
 #################
 ## Visual Studio

--- a/lib/gonode.js
+++ b/lib/gonode.js
@@ -72,13 +72,14 @@ Go.prototype.init = function(callback) {
 			return;
 		}
 
+		// simple extension check to detect if its a un compiles .go file
 		if (self.goFile.slice(-3).toLowerCase() === '.go') {
-            // Spawn go process within current working directory
-            self.proc = spawn('go', ['run', self.goFile], { cwd: self.options.cwd, env: process.env });
+			// Spawn go process within current working directory
+			self.proc = spawn('go', ['run', self.goFile], { cwd: self.options.cwd, env: process.env });
 		} else {
 			// Spawn go compiled file
-            self.proc = spawn( self.goFile, [], { cwd: self.options.cwd, env: process.env });
-        }
+			self.proc = spawn( self.goFile, [], { cwd: self.options.cwd, env: process.env });
+		}
 
 
 		// Setup handlers

--- a/lib/gonode.js
+++ b/lib/gonode.js
@@ -71,8 +71,15 @@ Go.prototype.init = function(callback) {
 			misc.callbackIfAvailable(callback, misc.getError('.go-file not found for given path.'));
 			return;
 		}
-		// Spawn go process within current working directory
-		self.proc = spawn('go', ['run', self.goFile], { cwd: self.options.cwd, env: process.env });
+
+		if (self.goFile.slice(-3).toLowerCase() === '.go') {
+            // Spawn go process within current working directory
+            self.proc = spawn('go', ['run', self.goFile], { cwd: self.options.cwd, env: process.env });
+		} else {
+			// Spawn go compiled file
+            self.proc = spawn( self.goFile, [], { cwd: self.options.cwd, env: process.env });
+        }
+
 
 		// Setup handlers
 		self.proc.stdout.on('data', function(data){

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gonode",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "gonode - Go for node.js",
   "main": "./lib/gonode.js",
   "scripts": {


### PR DESCRIPTION
the original script only spawns files with go extension.
It uses the shell command "go run file-name.go" 
that cannot run a compiled go file.

if you want to run a compiled file like .exe
you need to just run the file: "file-name.exe"

I've added a simple if statement to allow this.